### PR TITLE
docs: use new syntax for math rendering

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -3,5 +3,4 @@ destination: docs
 
 template:
   package: rotemplate
-  params:
-    mathjax: true
+  math-rendering: mathjax


### PR DESCRIPTION
rotemplate is now aligned with https://pkgdown.r-lib.org/articles/customise.html#math-rendering :smile_cat: 